### PR TITLE
fix show/hide pr files bug on student show

### DIFF
--- a/app/assets/javascripts/pull_requests.js
+++ b/app/assets/javascripts/pull_requests.js
@@ -8,9 +8,9 @@ function addShowPRListener(){
     e.preventDefault;
     e.stopPropagation;
     var btn = e.toElement;
-    var studentPRFiles = btn.getAttribute('data-id');
-    $("." + studentPRFiles).slideToggle('slow');
-    $("." + studentPRFiles).removeClass("hidden");
+    var prFilesId = btn.getAttribute('data-pr')
+    $("[data-pr-parent='" + prFilesId +  "']").slideToggle('slow');
+    $("[data-pr-parent='" + prFilesId +  "']").removeClass("hidden");
   })
 }
 

--- a/app/views/pull_request_files/_pull_request_file.html.erb
+++ b/app/views/pull_request_files/_pull_request_file.html.erb
@@ -1,4 +1,4 @@
-<div class="panel panel-default student-<%= pull_request_file.student.id %>" data-class="pr-file" data-id="<%=pull_request_file.filename_without_path%>" data-directory="<%=pull_request_file.filepath%>"data-student="<%=pull_request_file.student.id%>">
+<div class="panel panel-default student-<%= pull_request_file.student.id %>" data-class="pr-file" data-id="<%=pull_request_file.filename_without_path%>" data-directory="<%=pull_request_file.filepath%>"data-student="<%=pull_request_file.student.id%>" data-pr-parent="<%=pull_request_file.pull_request.id%>">
   <div class="panel-heading"><h4 class="panel-title"><%=pull_request_file.name %></h4></div>
   <div class="panel-body">
    <pre class="prettyprint lang-ruby linenums"><code><%= pull_request_file.content %></code></pre>

--- a/app/views/pull_requests/_pull_request.html.erb
+++ b/app/views/pull_requests/_pull_request.html.erb
@@ -1,4 +1,4 @@
-  <button data-id="student-<%= pull_request.student.id %>" class="btn btn-info show-pr">show PR</button>
+  <button data-id="student-<%= pull_request.student.id %>" data-pr="<%=pull_request.id%>", class="btn btn-info show-pr">show PR</button>
   <%=link_to "view on GitHub", pull_request.url, target: "blank", class: "btn btn-success"%>
   <ul>
     <%= render partial: "pull_request_files/pull_request_file", collection: pull_request.pull_request_files %>


### PR DESCRIPTION
match data attribute on show pr button to the pr files specific to that pr; show/hide the appropraite files on button click. previously was showing/hiding all files for all prs when you click any button.
